### PR TITLE
Add FASTA sequence input support to website

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -8,7 +8,6 @@
 		"resolveJsonModule": true,
 		"skipLibCheck": true,
 		"sourceMap": true,
-		"strict": true
 	}
 	// Path aliases are handled by https://kit.svelte.dev/docs/configuration#alias and https://kit.svelte.dev/docs/configuration#files
 	//

--- a/src/autotune.css
+++ b/src/autotune.css
@@ -167,5 +167,3 @@ th, td {
 details {
   display: none;
 }
-
-

--- a/static/hivclustering_browser.py
+++ b/static/hivclustering_browser.py
@@ -1,0 +1,7 @@
+import hivclustering.networkbuild
+from hivclustering import *
+
+# TODO: Discuss auto-profile - only goes to stdout, can't be redirected to file
+# PAIRWISE_DIST_FILE_NAME is a constant defined in the javascript code 
+hivclustering.networkbuild.sys.argv = ['', '--input', PAIRWISE_DIST_FILE_NAME, '--format', 'plain', '--auto-profile', '0']
+hivclustering.networkbuild.build_a_network()

--- a/yarn.lock
+++ b/yarn.lock
@@ -590,9 +590,9 @@ camelcase-css@^2.0.1:
   integrity sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==
 
 caniuse-lite@^1.0.30001400, caniuse-lite@^1.0.30001426:
-  version "1.0.30001435"
-  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001435.tgz"
-  integrity sha512-kdCkUTjR+v4YAJelyiDTqiu82BDr4W4CP5sgTA0ZBmqn30XfS2ZghPLMowik9TPhS+psWJiUNxsqLyurDbmutA==
+  version "1.0.30001517"
+  resolved "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001517.tgz"
+  integrity sha512-Vdhm5S11DaFVLlyiKu4hiUTkpZu+y1KA/rZZqVQfOD5YdDT/eQKlkt7NaE0WGOFgX32diqt9MiP9CAiFeRklaA==
 
 chalk@^4.0.0:
   version "4.1.2"


### PR DESCRIPTION
Using Biowasm to run tn93 in-browser and Pyodide to run hivclustering in-browser, users can now upload a multiple sequence alignment FASTA file that generates plots based on its pairwise distances and resulting network.