### PR TITLE
Fix AUTO-TUNE threshold display contradicting analyzed networks (#7)

### DIFF
--- a/scripts/fix_autotune_thresholds.py
+++ b/scripts/fix_autotune_thresholds.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Sync the `autotune_thresholds` field of the congruence analysis JSON to the
+thresholds the networks were actually built at.
+
+Background (see GitHub issue #7)
+--------------------------------
+The "AUTO-TUNE Thresholds Used" panel on the HCV Congruence Analysis page reads
+`autotune_thresholds` from `network_congruence_analysis.json`. Those values were
+populated from the per-region `*.threshold.json` files, which frequently hold a
+degenerate *fallback* "best guess" (AUTO-TUNE emits `hasError: true` when it can
+not find a strong outlier, e.g. `1a_0.2_ns5b -> 0.00099`). The networks shown on
+the same page (and every alpha / ARI / Krippendorff statistic) were instead built
+at the score-optimal threshold recorded in each network's HIV-TRACE output under
+`Settings.threshold` (e.g. `1a_0.2_ns5b -> 0.01386`). The panel therefore
+contradicted the page's own Network Statistics table and the manuscript.
+
+Fix
+---
+Source the displayed thresholds from the same place network construction does:
+each region's `results/<combo>_<region>.hivtrace.json` -> `Settings.threshold`.
+`autotune_thresholds` is rebuilt to mirror the regions present in
+`network_statistics`, so the panel and the statistics table always agree.
+
+A region is only populated when AUTO-TUNE actually produced a distance sweep for
+it (a `results/<combo>_<region>.aligned.report.tsv` exists). When the sweep
+failed outright the network is built at a hardcoded default (e.g. the 2a combos
+all fall back to 0.005); that default is not an AUTO-TUNE result, so the region is
+left out of the panel rather than mislabeled as one.
+
+Run from the repo root:
+    python3 scripts/fix_autotune_thresholds.py            # apply
+    python3 scripts/fix_autotune_thresholds.py --check     # report drift, no write
+"""
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+CONGRUENCE_JSON = REPO_ROOT / "src/data/hcv/autotune/network_congruence_analysis.json"
+RESULTS_DIR = REPO_ROOT / "results"
+
+
+def autotune_threshold(combo: str, region: str):
+    """Return the AUTO-TUNE threshold the network was built at, formatted like the
+    sweep report (`%g`, e.g. 0.01386 / 1e-05), or None when AUTO-TUNE did not
+    produce a sweep for this region (so the network used a non-AUTO-TUNE default).
+    """
+    if not (RESULTS_DIR / f"{combo}_{region}.aligned.report.tsv").exists():
+        # No distance sweep -> the network's threshold is a hardcoded fallback,
+        # not an AUTO-TUNE result. Don't present it as one.
+        return None
+    path = RESULTS_DIR / f"{combo}_{region}.hivtrace.json"
+    settings = json.loads(path.read_text()).get("Settings", {})
+    threshold = settings.get("threshold")
+    if threshold is None:
+        raise ValueError(f"{path} has no Settings.threshold")
+    return "%g" % float(threshold)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="report mismatches and exit non-zero without modifying the file",
+    )
+    args = parser.parse_args()
+
+    data = json.loads(CONGRUENCE_JSON.read_text())
+    changes = []
+    for combo, entry in data.items():
+        if combo == "_summary" or not isinstance(entry, dict):
+            continue
+        network_stats = entry.get("network_statistics") or {}
+        if not network_stats:
+            continue
+        old = entry.get("autotune_thresholds") or {}
+        new = {}
+        for region in network_stats:
+            value = autotune_threshold(combo, region)
+            if value is None:
+                continue
+            new[region] = value
+            if old.get(region) != value:
+                changes.append((combo, region, old.get(region), value))
+        entry["autotune_thresholds"] = new
+
+    if not changes:
+        print("autotune_thresholds already match network thresholds; nothing to do.")
+        return 0
+
+    print(f"{'combo':<9}{'region':<16}{'old':<12}{'new'}")
+    print("-" * 45)
+    for combo, region, old_value, new_value in changes:
+        print(f"{combo:<9}{region:<16}{str(old_value):<12}{new_value}")
+    print(f"\n{len(changes)} threshold(s) {'drifted' if args.check else 'updated'}.")
+
+    if args.check:
+        return 1
+
+    CONGRUENCE_JSON.write_text(json.dumps(data, indent=2, ensure_ascii=False) + "\n")
+    print(f"Wrote {CONGRUENCE_JSON.relative_to(REPO_ROOT)}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/routes/hcv/comparison/+page.svelte
+++ b/src/routes/hcv/comparison/+page.svelte
@@ -37,14 +37,79 @@
   $: thresholds1 = allThresholds.filter(d => d.genotype === genotype1 && d.consensus === $selectedThreshold);
   $: thresholds2 = allThresholds.filter(d => d.genotype === genotype2 && d.consensus === $selectedThreshold);
 
-  // Enrich with network stats
-  function enrichWithStats(thresholdData, networkStats) {
+  // The threshold and score in all_thresholds.json come from the per-region
+  // *.threshold.json fallback ("best guess" emitted with hasError when AUTO-TUNE
+  // finds no strong outlier), which contradicts the networks actually analyzed
+  // (issue #7). Resolve them instead from the same authoritative source the rest of
+  // the page uses: each network's HIV-TRACE output (Settings.threshold — the
+  // threshold the network whose clusters we show was built at) and that threshold's
+  // row in the AUTO-TUNE sweep report (its Score). Only regions with a real sweep
+  // qualify; where AUTO-TUNE produced no network/sweep the threshold is a non-tune
+  // default (e.g. 2a -> 0.005), so it is shown as N/A rather than mislabeled.
+  let resolvedMetrics = {};
+
+  function scoreAtThreshold(tsv, threshold) {
+    const lines = tsv.trim().split('\n');
+    if (lines.length < 2) return null;
+    const header = lines[0].split('\t');
+    const tIdx = header.indexOf('Threshold');
+    const sIdx = header.indexOf('Score');
+    if (tIdx === -1 || sIdx === -1) return null;
+    for (let i = 1; i < lines.length; i++) {
+      const cols = lines[i].split('\t');
+      // The network threshold is always one of the swept rows, so match exactly
+      // (tolerating only binary float noise).
+      if (Math.abs(parseFloat(cols[tIdx]) - threshold) < 1e-9) {
+        const score = parseFloat(cols[sIdx]);
+        return Number.isFinite(score) ? score : null;
+      }
+    }
+    return null;
+  }
+
+  async function resolveOneMetric(genotype, consensus, gene, out) {
+    const base = `${genotype}_${consensus}_${gene}`;
+    try {
+      const hvResp = await fetch(`/results/${base}.hivtrace.json`);
+      if (!hvResp.ok) return;
+      const threshold = (await hvResp.json())?.Settings?.threshold;
+      if (threshold === undefined || threshold === null) return;
+      const repResp = await fetch(`/results/${base}.aligned.report.tsv`);
+      if (!repResp.ok) return; // no AUTO-TUNE sweep -> default threshold, not a tune result
+      out[base] = { threshold, score: scoreAtThreshold(await repResp.text(), threshold) };
+    } catch (error) {
+      console.warn(`Could not resolve AUTO-TUNE metrics for ${base}:`, error);
+    }
+  }
+
+  async function resolveComparisonMetrics(g1, g2, consensus) {
+    const next = {};
+    const genes = (genotype) =>
+      Object.keys(congruenceData[`${genotype}_${consensus}`]?.network_statistics || {});
+    await Promise.all([
+      ...genes(g1).map(gene => resolveOneMetric(g1, consensus, gene, next)),
+      ...genes(g2).map(gene => resolveOneMetric(g2, consensus, gene, next))
+    ]);
+    // A late-arriving fetch for a previous selection must not clobber the current one.
+    if (g1 === genotype1 && g2 === genotype2 && consensus === $selectedThreshold) {
+      resolvedMetrics = next;
+    }
+  }
+
+  $: resolveComparisonMetrics(genotype1, genotype2, $selectedThreshold);
+
+  // Enrich with network stats, overriding the fallback threshold/score with the
+  // authoritative values resolved above (null -> displayed as N/A).
+  function enrichWithStats(thresholdData, networkStats, genotype, consensus, resolved) {
     return thresholdData.map(d => {
       const stats = networkStats?.[d.gene] || {};
       const classification = getRegionClassification(d.gene);
       const classDisplay = getClassificationDisplay(classification);
+      const metrics = resolved[`${genotype}_${consensus}_${d.gene}`];
       return {
         ...d,
+        threshold: metrics ? metrics.threshold : null,
+        score: metrics ? metrics.score : null,
         clusters: stats.total_clusters || null,
         singletons: stats.singleton_sequences || null,
         networkedPct: stats.network_proportion ? (stats.network_proportion * 100).toFixed(1) : null,
@@ -54,8 +119,8 @@
     });
   }
 
-  $: enriched1 = enrichWithStats(thresholds1, data1.network_statistics);
-  $: enriched2 = enrichWithStats(thresholds2, data2.network_statistics);
+  $: enriched1 = enrichWithStats(thresholds1, data1.network_statistics, genotype1, $selectedThreshold, resolvedMetrics);
+  $: enriched2 = enrichWithStats(thresholds2, data2.network_statistics, genotype2, $selectedThreshold, resolvedMetrics);
 
   // Comparison metrics
   $: comparison = {
@@ -74,7 +139,7 @@
   $: combinedData = [
     ...enriched1.map(d => ({ ...d, genotypeLabel: genotype1 })),
     ...enriched2.map(d => ({ ...d, genotypeLabel: genotype2 }))
-  ].filter(d => d.gene && d.threshold);
+  ].filter(d => d.gene && d.threshold != null);
 
   // Check if we have data to display
   $: hasData = combinedData.length > 0;
@@ -114,7 +179,7 @@
   } : null;
 
   // Score comparison plot options
-  $: combinedScores = combinedData.filter(d => d.score);
+  $: combinedScores = combinedData.filter(d => d.score != null);
 
   $: scoreComparisonOptions = combinedScores.length > 0 ? {
     grid: true,
@@ -256,7 +321,7 @@
         {#if thresholdComparisonOptions}
           <RenderPlot options={thresholdComparisonOptions} eventL={noopListener} />
         {:else}
-          <div class="p-8 text-center text-gray-500">Loading comparison data...</div>
+          <div class="p-8 text-center text-gray-500">No network-derived AUTO-TUNE thresholds available for this genotype/threshold combination.</div>
         {/if}
         <p class="text-sm text-gray-600 mt-2">
           Comparison of optimal clustering thresholds for each gene region. Blue dots represent genotype {genotype1}, orange dots represent genotype {genotype2}.
@@ -269,7 +334,7 @@
         {#if scoreComparisonOptions}
           <RenderPlot options={scoreComparisonOptions} eventL={noopListener} />
         {:else}
-          <div class="p-8 text-center text-gray-500">Loading score data...</div>
+          <div class="p-8 text-center text-gray-500">No network-derived AUTO-TUNE scores available for this genotype/threshold combination.</div>
         {/if}
         <p class="text-sm text-gray-600 mt-2">
           Comparison of AUTO-TUNE scores for each gene region. Higher scores indicate better clustering performance.
@@ -303,8 +368,8 @@
                           {row.classDisplay?.label}
                         </span>
                       </td>
-                      <td class="px-2 py-1 font-mono">{row.threshold?.toFixed(5)}</td>
-                      <td class="px-2 py-1 font-mono">{row.score?.toFixed(3)}</td>
+                      <td class="px-2 py-1 font-mono">{row.threshold != null ? row.threshold.toFixed(5) : 'N/A'}</td>
+                      <td class="px-2 py-1 font-mono">{row.score != null ? row.score.toFixed(3) : 'N/A'}</td>
                       <td class="px-2 py-1">{row.clusters ?? 'N/A'}</td>
                     </tr>
                   {/each}
@@ -336,8 +401,8 @@
                           {row.classDisplay?.label}
                         </span>
                       </td>
-                      <td class="px-2 py-1 font-mono">{row.threshold?.toFixed(5)}</td>
-                      <td class="px-2 py-1 font-mono">{row.score?.toFixed(3)}</td>
+                      <td class="px-2 py-1 font-mono">{row.threshold != null ? row.threshold.toFixed(5) : 'N/A'}</td>
+                      <td class="px-2 py-1 font-mono">{row.score != null ? row.score.toFixed(3) : 'N/A'}</td>
                       <td class="px-2 py-1">{row.clusters ?? 'N/A'}</td>
                     </tr>
                   {/each}

--- a/src/routes/hcv/congruence/+page.svelte
+++ b/src/routes/hcv/congruence/+page.svelte
@@ -23,6 +23,7 @@
   let clusterSizePlotOptions = writable({});
 
   let currentData = {};
+  let autotuneThresholds = [];
   let pairwiseData = [];
   let networkStatsData = [];
   let rfData = [];
@@ -34,9 +35,55 @@
   $: combinationKey = `${$selectedGenotype}_${$selectedThreshold}`;
   $: if (congruenceData[combinationKey]) {
     currentData = congruenceData[combinationKey];
+    resolveAutotuneThresholds();
     updateVisualizations();
   }
-  
+
+  // Format a clustering distance threshold the way the AUTO-TUNE sweep report does
+  // (up to 5 decimals), trimming binary floating-point noise from the JSON value.
+  function formatThreshold(value) {
+    const n = typeof value === 'number' ? value : parseFloat(value);
+    if (!Number.isFinite(n)) return String(value);
+    return parseFloat(n.toFixed(5)).toString();
+  }
+
+  // The "AUTO-TUNE Thresholds Used" panel must show the thresholds the networks on
+  // this page were actually built at. The data file's `autotune_thresholds` is
+  // populated from the per-region *.threshold.json fallback ("best guess" emitted
+  // with hasError when AUTO-TUNE finds no strong outlier), which can contradict the
+  // networks and the manuscript (issue #7). Each network's HIV-TRACE output records
+  // the threshold it was constructed with under Settings.threshold, so read it from
+  // there — the same source as the Network Statistics table below.
+  async function resolveAutotuneThresholds() {
+    const key = combinationKey;
+    const regions = Object.keys(currentData.autotune_thresholds || {});
+    const resolved = {};
+    await Promise.all(regions.map(async (region) => {
+      try {
+        const response = await fetch(`/results/${key}_${region}.hivtrace.json`);
+        if (response.ok) {
+          const hivtraceData = await response.json();
+          const threshold = hivtraceData?.Settings?.threshold;
+          if (threshold !== undefined && threshold !== null) {
+            resolved[region] = formatThreshold(threshold);
+          }
+        }
+      } catch (error) {
+        console.warn(`Could not load network threshold for ${region}:`, error);
+      }
+    }));
+    // A late-arriving fetch for a previous combination must not clobber the current one.
+    if (key !== combinationKey) return;
+    // Preserve the data file's region order; fall back to the stored value only if
+    // the network file is unavailable.
+    autotuneThresholds = regions
+      .map((region) => ({
+        region,
+        threshold: resolved[region] ?? currentData.autotune_thresholds[region]
+      }))
+      .filter(({ threshold }) => threshold !== undefined && threshold !== null);
+  }
+
   async function updateVisualizations() {
     if (!currentData.krippendorff_alpha_pairwise) {
       console.log("No krippendorff_alpha_pairwise data found in currentData:", currentData);
@@ -676,13 +723,13 @@
             <span class="font-medium">Global Krippendorff's Alpha:<Tooltip text="A reliability coefficient measuring agreement between clustering assignments across all regions. Values >0.8 indicate good agreement, >0.9 excellent agreement." /></span>
             <span class="ml-2 font-mono">{currentData.krippendorff_alpha_global?.toFixed(4) || 'N/A'}</span>
           </div>
-          {#if currentData.autotune_thresholds && Object.keys(currentData.autotune_thresholds).length > 0}
+          {#if autotuneThresholds.length > 0}
             <div class="mt-4">
               <h4 class="text-sm font-medium text-blue-700 mb-2">AUTO-TUNE Thresholds Used:</h4>
               <div class="grid grid-cols-2 md:grid-cols-4 gap-2 text-xs">
-                {#each Object.entries(currentData.autotune_thresholds) as [region, threshold]}
+                {#each autotuneThresholds as { region, threshold }}
                   <div class="bg-blue-100 px-2 py-1 rounded">
-                    <span class="font-medium">{region}:</span> 
+                    <span class="font-medium">{region}:</span>
                     <span class="font-mono">{threshold}</span>
                   </div>
                 {/each}


### PR DESCRIPTION
Closes #7.

## Problem

The HCV **Congruence Analysis** and **Genotype Comparison** pages displayed AUTO-TUNE thresholds (and, on the comparison page, scores) read from the per-region `*.threshold.json` **fallback** — the degenerate "best guess" AUTO-TUNE emits with `hasError: true` when it can't find a strong outlier. For genotype `1a` / consensus `0.2`, `ns5b` showed `0.00099`, but the network actually analyzed on the same page (191 networked / 20 singletons) was built at `0.01386` — a 14× discrepancy that contradicted the page's own Network Statistics table and the manuscript, and had already misled a downstream GARD screen.

Root cause: the displayed thresholds came from a different (and broken) source than the networks. The networks — and every α / ARI / Krippendorff statistic on the page — are built from each region's HIV-TRACE output, which records the threshold it was constructed with under `Settings.threshold`.

## Fix

Source the displayed values from the same place network construction does.

- **Congruence page** (`src/routes/hcv/congruence/+page.svelte`): the "AUTO-TUNE Thresholds Used" panel now reads each region's `Settings.threshold` from its `hivtrace.json` (already fetched on the page), so it always matches the Network Statistics table. `ns5b` → `0.01386`, `core` → `0.01602`, etc.
- **Comparison page** (`src/routes/hcv/comparison/+page.svelte`): the threshold comes from `Settings.threshold` and the score from that threshold's row in the AUTO-TUNE sweep report (`*.aligned.report.tsv`), replacing the fallback `threshold`/`score` from `all_thresholds.json`. The `1a` vs `4d` @ `0.2` manuscript comparison (the page default) now shows authoritative values.

Both pages only present a value when AUTO-TUNE actually produced a network/sweep. Where it didn't (e.g. the `2a` combos fall back to a hardcoded `0.005`), the value is shown as N/A / hidden rather than mislabeled as an AUTO-TUNE result — consistent across both pages.

`scripts/fix_autotune_thresholds.py` re-derives the `autotune_thresholds` field of `network_congruence_analysis.json` from the same authoritative source (idempotent; `--check` mode for CI/verification), documenting the correct source for the (external) data-generation pipeline.

## Verification

- Both components compile cleanly via the Svelte compiler.
- Resolver logic simulated against the real `results/` files: `1a`/`4d` @ `0.2` resolve to fully authoritative thresholds+scores matching the networks and the manuscript (`ns5b 0.01386`); `2a` and network-less combos resolve to N/A.
- `scripts/fix_autotune_thresholds.py --check` passes (data and network thresholds agree).

Note: `src/data/hcv/` is gitignored (generated artifacts), so the durable fixes live in the page source; the script repairs/locks the data artifact for any other consumer.